### PR TITLE
15 norm fix functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ SRCS	= src/parser/check_element.c \
 		  src/calc/vec_length.c \
 		  src/calc/utils.c \
 		  src/raytracing/render.c \
+		  src/raytracing/render_utils.c \
 		  src/raytracing/obj_sphere.c \
 		  src/raytracing/obj_plane.c \
 		  src/raytracing/obj_cylinder.c \
@@ -57,7 +58,6 @@ SRCS	= src/parser/check_element.c \
 		  src/raytracing/texture.c \
 		  src/raytracing/texture_pl.c \
 		  src/raytracing/texture_sp.c \
-		  src/raytracing/image.c \
 		  src/raytracing/init.c
 OBJS_M  = $(SRCS_M:.c=.o)
 OBJS_B  = $(SRCS_B:.c=.o)

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ SRCS	= src/parser/check_element.c \
 		  src/raytracing/obj_cone.c \
 		  src/raytracing/screen.c \
 		  src/raytracing/hit.c \
+		  src/raytracing/hit_utils.c \
 		  src/raytracing/camera.c \
 		  src/raytracing/shade.c \
 		  src/raytracing/shadow.c \

--- a/includes/calc.h
+++ b/includes/calc.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   calc.h                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tamatsuu <tamatsuu@student.42.fr>          +#+  +:+       +#+        */
+/*   By: yosshii <yosshii@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/12 06:14:16 by yotsurud          #+#    #+#             */
-/*   Updated: 2025/04/20 18:54:00 by tamatsuu         ###   ########.fr       */
+/*   Updated: 2026/04/18 02:17:17 by yosshii          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,7 +35,7 @@ double	vec_dist(t_xyz a, t_xyz b);
 // utils.c
 double	sqr(double x);
 double	deg_to_rad(double deg);
-bool	solve_quadratic(double abc[3], double *t0, double *t1);
+bool	solve_quadratic(t_cy *cy, double *t0, double *t1);
 t_xyz	make_xyz(double x, double y, double z);
 
 #endif

--- a/includes/parser.h
+++ b/includes/parser.h
@@ -6,7 +6,7 @@
 /*   By: yosshii <yosshii@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/12 06:06:40 by yotsurud          #+#    #+#             */
-/*   Updated: 2026/04/17 16:56:47 by yosshii          ###   ########.fr       */
+/*   Updated: 2026/04/17 21:28:39 by yosshii          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -88,8 +88,6 @@ void			set_texture(char **split, t_obj *new, int count);
 //make_obj_cy_cn.c
 void			set_cy_data(char **split, t_obj *new);
 void			set_cn_data(char **split, t_obj *new);
-
-
 
 //parser.c
 void			parser(char *filename, int part);

--- a/includes/raytracing.h
+++ b/includes/raytracing.h
@@ -6,7 +6,7 @@
 /*   By: yosshii <yosshii@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/23 20:10:58 by yotsurud          #+#    #+#             */
-/*   Updated: 2026/04/18 02:53:11 by yosshii          ###   ########.fr       */
+/*   Updated: 2026/04/18 13:41:44 by yosshii          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,8 +55,7 @@ void			check_light_pos(t_obj *obj, t_env *env, t_ray cam_ray);
 // shade.c
 t_xyz			calc_shade(t_obj *obj, t_lit *lit, t_hit_point hit_obj,
 					t_ray cam_ray);
-t_xyz			pls_shade(t_obj *obj, t_hit_point hit, t_lit *lit,
-					double diff_ref, double spec_ref);
+t_xyz			pls_shade(t_data_set data, double diff_ref, double spec_ref);
 int				set_amb_col(t_xyz *color, t_env *env);
 void			pls_amb_color(t_obj *obj, t_env *env, t_xyz *col,
 					t_hit_point hit);
@@ -93,6 +92,10 @@ double			hit_cam_ray(t_obj *obj, t_ray *ray, t_hit_point *h_obj,
 int				hit_shadow_ray(t_obj *obj, t_ray *sh_ray, t_hit_point *hit_p);
 int				hit_nearest_obj(t_obj *obj, t_ray *ray, t_hit_point *hit_p);
 void			fill_hit_obj(t_obj *obj, t_ray c_ray, t_hit_point *h_obj);
+
+// hit_utils.c
+void			init_variables(int *ret, int *i, t_obj **obj_cpy, t_obj *obj);
+void			init_hit_p(t_hit_point *hit);
 void			set_face_normal(t_ray *ray, t_hit_point *h_obj);
 
 // obj_shpere.c

--- a/includes/raytracing.h
+++ b/includes/raytracing.h
@@ -6,7 +6,7 @@
 /*   By: yosshii <yosshii@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/23 20:10:58 by yotsurud          #+#    #+#             */
-/*   Updated: 2026/04/17 19:57:25 by yosshii          ###   ########.fr       */
+/*   Updated: 2026/04/18 02:53:11 by yosshii          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,13 @@
 # define NO_LIGHT 2
 
 // render.c
-int				ray_tracing(t_obj *obj, t_env *env, t_ray cam_ray, t_xyz *color);
+int				render_scene(t_mlx_env *mlx, t_obj *obj, t_env *env);
+int				ray_tracing(t_obj *obj, t_env *env, t_ray cam_ray,
+					t_xyz *color);
+
+// render_utils.c
+void			reset_light_flags(t_env *env);
+void			init_offset(double sx[4], double sy[4]);
 
 // camera.c
 t_xyz			calc_cam_dir(t_xyz screen_vec, t_xyz cam_vec);
@@ -36,19 +42,24 @@ t_xyz			calc_cam_dir(t_xyz screen_vec, t_xyz cam_vec);
 // screen.c
 double			convert_x_to_screen(double x);
 double			convert_y_to_screen(double y);
-void			set_screen_vector(t_xyz *screen, double x, double y, double fov);
+void			set_screen_vector(t_xyz *screen, double x, double y,
+					double fov);
 
 // light.c
-void			check_light_and_cam_pos(t_obj *obj, t_lit *lit, t_ray cam_ray);
+void			check_light_and_cam_pos(t_obj *obj, t_lit *lit,
+					t_ray cam_ray);
 void			is_light_inside_cy(t_obj *obj, t_lit *lit);
 void			is_light_inside_sp(t_obj *obj, t_lit *lit);
 void			check_light_pos(t_obj *obj, t_env *env, t_ray cam_ray);
 
 // shade.c
-t_xyz			calc_shade(t_obj *obj, t_lit *lit, t_hit_point hit_obj, t_ray cam_ray);
-t_xyz			pls_shade(t_obj *obj, t_hit_point hit, t_lit *lit, double diff_ref, double spec_ref);
+t_xyz			calc_shade(t_obj *obj, t_lit *lit, t_hit_point hit_obj,
+					t_ray cam_ray);
+t_xyz			pls_shade(t_obj *obj, t_hit_point hit, t_lit *lit,
+					double diff_ref, double spec_ref);
 int				set_amb_col(t_xyz *color, t_env *env);
-void			pls_amb_color(t_obj *obj, t_env *env, t_xyz *col, t_hit_point hit);
+void			pls_amb_color(t_obj *obj, t_env *env, t_xyz *col,
+					t_hit_point hit);
 
 // shadow.c
 int				calc_shadow(t_obj *obj, t_lit *lit, t_hit_point *hit_p);
@@ -64,21 +75,23 @@ void			color_set_to_pixel(t_meta_img *img, int x, int y,
 t_xyz			get_optional_color(t_obj *obj, t_hit_point hit);
 unsigned int	get_tex_pixel(t_meta_img *tex, int x, int y);
 t_xyz			color_from_int(unsigned int c);
-					
+
 // texture_pl.c
 t_xyz			get_pl_checker_color(t_obj *obj, t_hit_point hit);
-t_xyz			get_pl_texture_color(t_obj *obj, t_hit_point hit, t_meta_img *tex);
+t_xyz			get_pl_texture_color(t_obj *obj, t_hit_point hit,
+					t_meta_img *tex);
 
 // texture_sp.c
 void			get_sp_uv(t_obj *obj, t_hit_point hit, double *u, double *v);
 t_xyz			get_sp_checker_color(t_obj *obj, t_hit_point hit);
-t_xyz			get_sp_texture_color(t_obj *obj, t_hit_point hit, t_meta_img *tex);
+t_xyz			get_sp_texture_color(t_obj *obj, t_hit_point hit,
+					t_meta_img *tex);
 
 // hit.c
 double			hit_cam_ray(t_obj *obj, t_ray *ray, t_hit_point *h_obj,
 					bool rec_hit);
-int				hit_nearest_obj(t_obj *obj, t_ray *ray, t_hit_point *hit_p);
 int				hit_shadow_ray(t_obj *obj, t_ray *sh_ray, t_hit_point *hit_p);
+int				hit_nearest_obj(t_obj *obj, t_ray *ray, t_hit_point *hit_p);
 void			fill_hit_obj(t_obj *obj, t_ray c_ray, t_hit_point *h_obj);
 void			set_face_normal(t_ray *ray, t_hit_point *h_obj);
 
@@ -98,20 +111,16 @@ bool			hit_cy_core(t_cy *cy, t_hit_point *hit);
 // obj_cylinder_core.c
 bool			hit_cy_side(t_cy *cy, t_hit_point *hit);
 bool			hit_cy_caps(t_cy *cy, t_hit_point *hit);
-bool			hit_cy_cap(t_cy *cy, t_xyz center, t_xyz normal, t_hit_part part,
+bool			hit_cy_cap(t_cy *cy, t_xyz normal, t_hit_part part,
 					t_hit_point *hit);
-bool			judge_t(t_cy *cy, t_hit_point *hit, double t);
-void			calc_cy_side_abc(t_cy *cy, double abc[3]);
 
 // obj_cone.c
-double			hit_cone(t_obj *obj, t_ray *ray, t_hit_point *h_obj, bool rec_hit);
+double			hit_cone(t_obj *obj, t_ray *ray, t_hit_point *h_obj,
+					bool rec_hit);
 
 // init.c
 void			init_t_hit_point(t_hit_point *tmp);
+void			set_init_cylinder_data(t_cy *cy, t_obj *obj, t_ray *ray);
 void			set_init_cone_data(t_cn *cn, t_obj *obj, t_ray *ray);
-
-// unused
-void			set_hit_obj(t_obj *obj, t_ray *ray, t_hit_point *h_obj,
-					double dist);
 
 #endif

--- a/includes/types.h
+++ b/includes/types.h
@@ -89,7 +89,6 @@ typedef enum e_hit_part
 	HIT_CY_SIDE,
 	HIT_CY_CAP_TOP,
 	HIT_CY_CAP_BOTTOM,
-	
 	HIT_SPHERE,
 	hIT_PLANE
 }	t_hit_part;
@@ -119,6 +118,12 @@ typedef struct s_cy
 	double	half_h;
 	double	min;
 	double	max;
+	t_xyz	top;
+	t_xyz	bottom;
+	t_xyz	oc;
+	double	a;
+	double	b;
+	double	c;
 }	t_cy;
 
 typedef struct s_cn

--- a/includes/types.h
+++ b/includes/types.h
@@ -142,4 +142,11 @@ typedef struct s_cn
 	double	c;
 }	t_cn;
 
+typedef struct s_data_set
+{
+	t_obj		*obj;
+	t_lit		*lit;
+	t_hit_point	hit_p;
+}	t_data_set;
+
 #endif

--- a/includes/ui.h
+++ b/includes/ui.h
@@ -6,7 +6,7 @@
 /*   By: yosshii <yosshii@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/23 20:08:53 by yotsurud          #+#    #+#             */
-/*   Updated: 2026/04/16 22:00:55 by yosshii          ###   ########.fr       */
+/*   Updated: 2026/04/17 22:13:45 by yosshii          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,11 +21,12 @@
 # define WIN_TITLE "minirt"
 # define DESTROY_NOTIFY 17
 
-int		close_btn_click(t_mlx_env *mlx);
+// init_window.c
 int		init_window(t_obj *obj, t_env *env);
 int		render_window(t_mlx_env *mlx, t_obj *obj, t_env *env);
-int		render_scene(t_mlx_env *mlx, t_obj *obj, t_env *env);
-double	hit_ray(t_obj *obj, t_env *env, t_xyz cam_dir);
+
+// close_handler.c
+int		close_btn_click(t_mlx_env *mlx);
 int		key_handler(int keycode, t_mlx_env *mlx);
 
 #endif

--- a/src/calc/utils.c
+++ b/src/calc/utils.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   normalize.c                                        :+:      :+:    :+:   */
+/*   utils.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tamatsuu <tamatsuu@student.42.fr>          +#+  +:+       +#+        */
+/*   By: yosshii <yosshii@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/12 05:29:01 by yotsurud          #+#    #+#             */
-/*   Updated: 2025/04/20 18:52:46 by tamatsuu         ###   ########.fr       */
+/*   Updated: 2026/04/18 02:16:53 by yosshii          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,28 +23,28 @@ double	deg_to_rad(double deg)
 	return (deg * M_PI / 180.0);
 }
 
-bool	solve_quadratic(double abc[3], double *t0, double *t1)
+bool	solve_quadratic(t_cy *cy, double *t0, double *t1)
 {
 	double	d;
 	double	tmp;
 
-	if (fabs(abc[0]) < EPS)
+	if (fabs(cy->a) < EPS)
 		return (false);
-	d = abc[1] * abc[1] - 4.0 * abc[0] * abc[2];
+	d = sqr(cy->b) - 4.0 * cy->a * cy->c;
 	if (d < -EPS)
 		return (false);
 	if (d < 0.0)
 		d = 0.0;
 	d = sqrt(d);
-	*t0 = (-abc[1] - d) / (2.0 * abc[0]);
-	*t1 = (-abc[1] + d) / (2.0 * abc[0]);
+	*t0 = (-cy->b - d) / (2.0 * cy->a);
+	*t1 = (-cy->b + d) / (2.0 * cy->a);
 	if (*t1 < *t0)
 	{
 		tmp = *t0;
 		*t0 = *t1;
 		*t1 = tmp;
 	}
-	return (true); 
+	return (true);
 }
 
 t_xyz	make_xyz(double x, double y, double z)

--- a/src/parser/check_element.c
+++ b/src/parser/check_element.c
@@ -6,7 +6,7 @@
 /*   By: yosshii <yosshii@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/12 05:14:27 by yotsurud          #+#    #+#             */
-/*   Updated: 2026/04/17 17:20:09 by yosshii          ###   ########.fr       */
+/*   Updated: 2026/04/17 21:21:18 by yosshii          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 
 int	check_first_element(char *str)
 {
-	if ((*str == 'A' && str[1] == '\0')|| (*str == 'C' && str[1] == '\0'))
+	if ((*str == 'A' && str[1] == '\0') || (*str == 'C' && str[1] == '\0'))
 		return (ENV);
 	if ((*str == 'L' && str[1] == '\0'))
 		return (LIT);

--- a/src/parser/make_env_data.c
+++ b/src/parser/make_env_data.c
@@ -6,7 +6,7 @@
 /*   By: yosshii <yosshii@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/12 05:19:57 by yotsurud          #+#    #+#             */
-/*   Updated: 2026/04/15 07:10:57 by yosshii          ###   ########.fr       */
+/*   Updated: 2026/04/18 13:54:25 by yosshii          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,9 +17,9 @@ void	make_env_data(char **split)
 	t_env	*env;
 
 	env = set_get_env(GET, NULL);
-	if (ft_memcmp(split[0], "A", 2) == 0)
+	if (split[0][0] == 'A' && split[0][1] == '\0')
 		set_amb_data(split, env);
-	else if (ft_memcmp(split[0], "C", 2) == 0)
+	else if (split[0][0] == 'C' && split[0][1] == '\0')
 		set_cam_data(split, env);
 }
 

--- a/src/parser/make_obj_pl_sp.c
+++ b/src/parser/make_obj_pl_sp.c
@@ -49,7 +49,7 @@ void	set_sp_data(char **split, t_obj *new)
 	double	xyz[3];
 	double	rgb[3];
 	int		count;
-	
+
 	count = count_split(split);
 	if (count < 4 || 6 < count)
 		print_error_and_exit("set_sp_data", "invalid argument count");

--- a/src/raytracing/hit.c
+++ b/src/raytracing/hit.c
@@ -6,13 +6,13 @@
 /*   By: yosshii <yosshii@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/23 00:31:53 by tamatsuu          #+#    #+#             */
-/*   Updated: 2026/04/17 18:04:54 by yosshii          ###   ########.fr       */
+/*   Updated: 2026/04/18 01:44:55 by yosshii          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../../includes/parser.h"
-#include "../../includes/raytracing.h"
-#include "../../includes/calc.h"
+#include "parser.h"
+#include "raytracing.h"
+#include "calc.h"
 
 double	hit_cam_ray(t_obj *obj, t_ray *ray, t_hit_point *h_obj, bool rec_hit)
 {
@@ -27,11 +27,39 @@ double	hit_cam_ray(t_obj *obj, t_ray *ray, t_hit_point *h_obj, bool rec_hit)
 	return (NO_HIT);
 }
 
+int	hit_shadow_ray(t_obj *obj, t_ray *sh_ray, t_hit_point *hit_p)
+{
+	t_obj		*obj_cpy;
+	t_hit_point	tmp_hit;
+	double		tmp_dist;
+	int			i;
+	int			ret;
+
+	ret = -1;
+	i = 0;
+	obj_cpy = obj;
+	while (obj_cpy)
+	{
+		if (hit_p->index != i)
+		{
+			tmp_hit = *hit_p;
+			tmp_dist = hit_cam_ray(obj_cpy, sh_ray, &tmp_hit, false);
+			if (tmp_dist > EPSILON && tmp_dist < MAX_DIST
+				&& tmp_dist < hit_p->dist)
+			{
+				*hit_p = tmp_hit;
+				hit_p->dist = tmp_dist;
+				ret = i;
+			}
+		}
+		obj_cpy = obj_cpy->next;
+		i++;
+	}
+	return (ret);
+}
+
 // this funciton will return the index of object which is nearest
 // -1 means there is no object which camera ray hit
-// 各オブジェクト判定は
-// まず tmp_hit に書く
-// 本当に「今の最短」だったときだけ hit_p に反映する
 int	hit_nearest_obj(t_obj *obj, t_ray *ray, t_hit_point *hit_p)
 {
 	t_obj		*obj_cpy;
@@ -64,41 +92,6 @@ int	hit_nearest_obj(t_obj *obj, t_ray *ray, t_hit_point *hit_p)
 	return (ret);
 }
 
-// 各オブジェクト判定は
-// まず tmp_hit に書く
-// 本当に「今の最短」だったときだけ hit_p に反映する
-int	hit_shadow_ray(t_obj *obj, t_ray *sh_ray, t_hit_point *hit_p)
-{
-	t_obj		*obj_cpy;
-	t_hit_point	tmp_hit;
-	double		tmp_dist;
-	int			i;
-	int			ret;
-
-	ret = -1;
-	i = 0;
-	obj_cpy = obj;
-	while (obj_cpy)
-	{
-		if (hit_p->index != i)
-		{
-			tmp_hit = *hit_p;
-			tmp_dist = hit_cam_ray(obj_cpy, sh_ray, &tmp_hit, false);
-			if (tmp_dist > EPSILON && tmp_dist < MAX_DIST
-				&& tmp_dist < hit_p->dist)
-			{
-				*hit_p = tmp_hit;
-				hit_p->dist = tmp_dist;
-				ret = i;
-			}
-		}
-		obj_cpy = obj_cpy->next;
-		i++;
-	}
-	return (ret);
-}
-
-// dist が決まった後に、pos と norm を完成させる関　sphere-ok
 void	fill_hit_obj(t_obj *obj, t_ray c_ray, t_hit_point *h_obj)
 {
 	h_obj->pos = vec_add(c_ray.pos, vec_scale(c_ray.dir, h_obj->dist));
@@ -113,50 +106,10 @@ void	fill_hit_obj(t_obj *obj, t_ray c_ray, t_hit_point *h_obj)
 		if (dot(c_ray.dir, h_obj->norm) > 0)
 			h_obj->norm = vec_scale(h_obj->norm, -1);
 	}
-	// else if (obj->id == CY)
-	// 	set_h_obj_cy(obj, &c_ray, h_obj, &h_obj->dist);
 }
 
 void	set_face_normal(t_ray *ray, t_hit_point *h_obj)
 {
 	if (dot(ray->dir, h_obj->norm) > 0)
 		h_obj->norm = vec_scale(h_obj->norm, -1.0);
-}
-
-void	set_hit_obj(t_obj *obj, t_ray *ray, t_hit_point *h_obj, double dist)
-{
-	h_obj->dist = dist;
-	h_obj->pos = vec_add(ray->pos, vec_scale(ray->dir, h_obj->dist));
-	if (obj->id == SP)
-	{
-		h_obj->norm = vec_sub(h_obj->pos, obj->xyz);
-		h_obj->norm = normalize(h_obj->norm);
-	}
-	else if (obj->id == PL)
-		h_obj->norm = normalize(obj->vector);
-}
-
-void	set_h_obj_cy(t_obj *obj, t_ray *ray, t_hit_point *h_obj, double *t)
-{
-	t_xyz	obj_center;
-	t_xyz	obj_vector;
-	t_xyz	pos;
-	double	s;
-
-	if (t[0] == NO_HIT)
-		return ;
-	h_obj->dist = t[0];
-	h_obj->pos = vec_add(ray->pos, vec_scale(ray->dir, h_obj->dist));
-	obj_center = obj->xyz;
-	obj_vector = normalize(obj->vector);
-	s = dot(vec_sub(h_obj->pos, obj_center), obj_vector);
-	if (s >= 0 && s <= obj->height)
-	{
-		pos = vec_add(obj_center, vec_scale(obj_vector, s));
-		h_obj->norm = normalize(vec_sub(h_obj->pos, pos));
-	}
-	else if (s < 0)
-		h_obj->norm = vec_scale(obj_vector, -1);
-	else
-		h_obj->norm = obj_vector;
 }

--- a/src/raytracing/hit.c
+++ b/src/raytracing/hit.c
@@ -6,7 +6,7 @@
 /*   By: yosshii <yosshii@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/23 00:31:53 by tamatsuu          #+#    #+#             */
-/*   Updated: 2026/04/18 01:44:55 by yosshii          ###   ########.fr       */
+/*   Updated: 2026/04/18 13:09:06 by yosshii          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,9 +35,7 @@ int	hit_shadow_ray(t_obj *obj, t_ray *sh_ray, t_hit_point *hit_p)
 	int			i;
 	int			ret;
 
-	ret = -1;
-	i = 0;
-	obj_cpy = obj;
+	init_variables(&ret, &i, &obj_cpy, obj);
 	while (obj_cpy)
 	{
 		if (hit_p->index != i)
@@ -68,11 +66,8 @@ int	hit_nearest_obj(t_obj *obj, t_ray *ray, t_hit_point *hit_p)
 	int			i;
 	int			ret;
 
-	hit_p->dist = MAX_DIST + 1;
-	hit_p->index = -1;
-	ret = -1;
-	i = 0;
-	obj_cpy = obj;
+	init_hit_p(hit_p);
+	init_variables(&ret, &i, &obj_cpy, obj);
 	while (obj_cpy)
 	{
 		tmp_hit = *hit_p;
@@ -106,10 +101,4 @@ void	fill_hit_obj(t_obj *obj, t_ray c_ray, t_hit_point *h_obj)
 		if (dot(c_ray.dir, h_obj->norm) > 0)
 			h_obj->norm = vec_scale(h_obj->norm, -1);
 	}
-}
-
-void	set_face_normal(t_ray *ray, t_hit_point *h_obj)
-{
-	if (dot(ray->dir, h_obj->norm) > 0)
-		h_obj->norm = vec_scale(h_obj->norm, -1.0);
 }

--- a/src/raytracing/hit_utils.c
+++ b/src/raytracing/hit_utils.c
@@ -1,0 +1,22 @@
+#include "parser.h"
+#include "raytracing.h"
+#include "calc.h"
+
+void	init_variables(int *ret, int *i, t_obj **obj_cpy, t_obj *obj)
+{
+	*ret = -1;
+	*i = 0;
+	*obj_cpy = obj;
+}
+
+void	init_hit_p(t_hit_point *hit)
+{
+	hit->dist = MAX_DIST + 1;
+	hit->index = -1;
+}
+
+void	set_face_normal(t_ray *ray, t_hit_point *h_obj)
+{
+	if (dot(ray->dir, h_obj->norm) > 0)
+		h_obj->norm = vec_scale(h_obj->norm, -1.0);
+}

--- a/src/raytracing/image.c
+++ b/src/raytracing/image.c
@@ -1,5 +1,0 @@
-#include "raytracing.h"
-#include "calc.h"
-
-
-

--- a/src/raytracing/init.c
+++ b/src/raytracing/init.c
@@ -9,6 +9,20 @@ void	init_t_hit_point(t_hit_point *tmp)
 	init_xyz(&tmp->norm);
 }
 
+void	set_init_cylinder_data(t_cy *cy, t_obj *obj, t_ray *ray)
+{
+	cy->ray = *ray;
+	cy->obj = obj;
+	cy->axis = normalize(obj->vector);
+	cy->radius = obj->diameter / 2.0;
+	cy->half_h = obj->height / 2.0;
+	cy->min = EPS;
+	cy->max = MAX_DIST;
+	cy->top = vec_add(cy->obj->xyz, vec_scale(cy->axis, cy->half_h));
+	cy->bottom = vec_sub(cy->obj->xyz, vec_scale(cy->axis, cy->half_h));
+	cy->oc = vec_sub(ray->pos, obj->xyz);
+}
+
 void	set_init_cone_data(t_cn *cn, t_obj *obj, t_ray *ray)
 {
 	cn->ray = *ray;

--- a/src/raytracing/obj_cone.c
+++ b/src/raytracing/obj_cone.c
@@ -39,14 +39,13 @@ static bool	hit_cone_side(t_cn *cn, t_hit_point *hit)
 	if (fabs(cn->a) < EPS)
 		return (false);
 	cn->b = 2.0 * (dot(cn->ray.dir, cn->co)
-		- (1.0 + cn->k) * cn->dir_axis * cn->co_axis);
+			- (1.0 + cn->k) * cn->dir_axis * cn->co_axis);
 	cn->c = dot(cn->co, cn->co) - (1.0 + cn->k) * sqr(cn->co_axis);
 	discriminant = sqr(cn->b) - 4.0 * cn->a * cn->c;
 	if (discriminant < 0)
 		return (false);
 	t0 = (-cn->b - sqrt(discriminant)) / (2.0 * cn->a);
 	t1 = (-cn->b + sqrt(discriminant)) / (2.0 * cn->a);
-
 	if (t0 > EPSILON && judge_cone_t(cn, hit, t0))
 		return (true);
 	if (t1 > EPSILON && judge_cone_t(cn, hit, t1))

--- a/src/raytracing/obj_cylinder.c
+++ b/src/raytracing/obj_cylinder.c
@@ -13,13 +13,7 @@ double	hit_cylinder(t_obj *obj, t_ray *ray, t_hit_point *h_obj, bool rec_hit)
 	t_cy		cy;
 	t_hit_point	tmp;
 
-	cy.ray = *ray;
-	cy.obj = obj;
-	cy.axis = normalize(obj->vector);
-	cy.radius = obj->diameter / 2.0;
-	cy.half_h = obj->height / 2.0;
-	cy.min = EPS;
-	cy.max = MAX_DIST;
+	set_init_cylinder_data(&cy, obj, ray);
 	init_t_hit_point(&tmp);
 	if (!hit_cy_core(&cy, &tmp))
 		return (NO_HIT);

--- a/src/raytracing/obj_cylinder_core.c
+++ b/src/raytracing/obj_cylinder_core.c
@@ -2,6 +2,57 @@
 #include "parser.h"
 #include "raytracing.h"
 
+// cylinder side quadratic coefficients
+/*
+** calc_cy_side_abc
+** 円柱側面の交差判定に必要な二次方程式の係数 a, b, c を計算
+** レイを円柱の式に代入すると
+**    a t^2 + b t + c = 0
+** という形になる
+** 1. oc = ray.origin - cylinder.center
+** 2. 円柱軸方向成分を除いたベクトルを使って計算
+**    → cross を使うことで軸方向を排除
+** 3. a, b, c を求める
+** ※ この係数は solve_quadratic() に渡す
+*/
+static void	calc_cy_side_abc(t_cy *cy)
+{
+	t_xyz	d_cross;
+	t_xyz	oc_cross;
+
+	d_cross = cross(cy->ray.dir, cy->axis);
+	oc_cross = cross(cy->oc, cy->axis);
+	cy->a = dot(d_cross, d_cross);
+	cy->b = 2.0 * dot(d_cross, oc_cross);
+	cy->c = dot(oc_cross, oc_cross) - cy->radius * cy->radius;
+}
+
+// ** 4. 交点 P を求める
+// ** 5. 軸方向距離 s を計算
+// **    → s = (P - center)・axis
+// ** 6. -half_h <= s <= half_h を満たすか確認
+// **    → 円柱の高さ範囲内かチェック
+// ** 7. 側面法線を計算
+// **    → 軸からの放射方向
+static bool	judge_cylinder_t(t_cy *cy, t_hit_point *hit, double t)
+{
+	t_xyz	pos;
+	double	s;
+
+	pos = vec_add(cy->ray.pos, vec_scale(cy->ray.dir, t));
+	s = dot(vec_sub(pos, cy->obj->xyz), cy->axis);
+	if (-cy->half_h <= s && s <= cy->half_h)
+	{
+		hit->dist = t;
+		hit->pos = pos;
+		hit->norm = normalize(vec_sub(pos,
+					vec_add(cy->obj->xyz, vec_scale(cy->axis, s))));
+		hit->part = HIT_CY_SIDE;
+		return (true);
+	}
+	return (false);
+}
+
 /*
 ** hit_cy_side
 **
@@ -14,7 +65,6 @@
 */
 bool	hit_cy_side(t_cy *cy, t_hit_point *hit)
 {
-	double		abc[3];
 	double		t0;
 	double		t1;
 	bool		found;
@@ -22,15 +72,15 @@ bool	hit_cy_side(t_cy *cy, t_hit_point *hit)
 
 	found = false;
 	init_t_hit_point(&tmp);
-	calc_cy_side_abc(cy, abc);
-	if (!solve_quadratic(abc, &t0, &t1))
+	calc_cy_side_abc(cy);
+	if (!solve_quadratic(cy, &t0, &t1))
 		return (false);
-	if (cy->min <= t0 && t0 <= cy->max && judge_t(cy, &tmp, t0))
+	if (cy->min <= t0 && t0 <= cy->max && judge_cylinder_t(cy, &tmp, t0))
 	{
 		*hit = tmp;
 		found = true;
 	}
-	if (cy->min <= t1 && t1 <= cy->max && judge_t(cy, &tmp, t1))
+	if (cy->min <= t1 && t1 <= cy->max && judge_cylinder_t(cy, &tmp, t1))
 	{
 		if (!found || tmp.dist < hit->dist)
 			*hit = tmp;
@@ -54,21 +104,16 @@ bool	hit_cy_side(t_cy *cy, t_hit_point *hit)
 bool	hit_cy_caps(t_cy *cy, t_hit_point *hit)
 {
 	t_hit_point	tmp;
-	t_xyz		top;
-	t_xyz		bottom;
 	bool		found;
 
 	init_t_hit_point(&tmp);
-	top = vec_add(cy->obj->xyz, vec_scale(cy->axis, cy->half_h));
-	bottom = vec_sub(cy->obj->xyz, vec_scale(cy->axis, cy->half_h));
 	found = false;
-	if (hit_cy_cap(cy, top, cy->axis, HIT_CY_CAP_TOP, &tmp))
+	if (hit_cy_cap(cy, cy->axis, HIT_CY_CAP_TOP, &tmp))
 	{
 		*hit = tmp;
 		found = true;
 	}
-	if (hit_cy_cap(cy, bottom, vec_scale(cy->axis, -1.0),
-			HIT_CY_CAP_BOTTOM, &tmp))
+	if (hit_cy_cap(cy, vec_scale(cy->axis, -1.0), HIT_CY_CAP_BOTTOM, &tmp))
 	{
 		if (!found || tmp.dist < hit->dist)
 			*hit = tmp;
@@ -90,14 +135,18 @@ bool	hit_cy_caps(t_cy *cy, t_hit_point *hit)
 **    → |P - center|² <= radius²
 ** 6. ヒット情報（距離・位置・法線）を設定
 */
-bool	hit_cy_cap(t_cy *cy, t_xyz center, t_xyz normal, t_hit_part part,
-	t_hit_point *hit)
+bool	hit_cy_cap(t_cy *cy, t_xyz normal, t_hit_part part, t_hit_point *hit)
 {
 	double	denom;
 	double	t;
 	t_xyz	position;
 	t_xyz	direction;
+	t_xyz	center;
 
+	if (part == HIT_CY_CAP_TOP)
+		center = cy->top;
+	else
+		center = cy->bottom;
 	denom = dot(cy->ray.dir, normal);
 	if (fabs(denom) < EPS)
 		return (false);
@@ -113,62 +162,4 @@ bool	hit_cy_cap(t_cy *cy, t_xyz center, t_xyz normal, t_hit_part part,
 	hit->norm = normal;
 	hit->part = part;
 	return (true);
-}
-
-// cylinder side quadratic coefficients
-/*
-** calc_cy_side_abc
-** 円柱側面の交差判定に必要な二次方程式の係数 a, b, c を計算
-** レイを円柱の式に代入すると
-**    a t^2 + b t + c = 0
-** という形になる
-** 1. oc = ray.origin - cylinder.center
-** 2. 円柱軸方向成分を除いたベクトルを使って計算
-**    → cross を使うことで軸方向を排除
-** 3. a, b, c を求める
-** ※ この係数は solve_quadratic() に渡す
-*/
-void	calc_cy_side_abc(t_cy *cy, double abc[3])
-{
-	t_xyz	oc;
-	t_xyz	d_cross;
-	t_xyz	oc_cross;
-
-	oc = vec_sub(cy->ray.pos, cy->obj->xyz);
-	d_cross = cross(cy->ray.dir, cy->axis);
-	oc_cross = cross(oc, cy->axis);
-	// abc[0] = vec_length_sq(cross(cy->ray.dir, cy->axis));
-	// abc[1] = 2.0 * dot(cross(cy->ray.dir, cy->axis), cross(oc, cy->axis));
-	// abc[2] = vec_length_sq(cross(oc, cy->axis)) - sqr(cy->radius);
-	abc[0] = dot(d_cross, d_cross);
-	abc[1] = 2.0 * dot(d_cross, oc_cross);
-	abc[2] = dot(oc_cross, oc_cross) - cy->radius * cy->radius;
-}
-
-// ** 4. 交点 P を求める
-// ** 5. 軸方向距離 s を計算
-// **    → s = (P - center)・axis
-// ** 6. -half_h <= s <= half_h を満たすか確認
-// **    → 円柱の高さ範囲内かチェック
-// ** 7. 側面法線を計算
-// **    → 軸からの放射方向
-bool	judge_t(t_cy *cy, t_hit_point *hit, double t)
-{
-	t_xyz	pos;
-	double	s;
-
-	pos = vec_add(cy->ray.pos, vec_scale(cy->ray.dir, t));
-	s = dot(vec_sub(pos, cy->obj->xyz), cy->axis);
-	if (-cy->half_h <= s && s <= cy->half_h)
-	{
-		hit->dist = t;
-		hit->pos = pos;
-		hit->norm = normalize(vec_sub(pos,
-					vec_add(cy->obj->xyz, vec_scale(cy->axis, s))));
-		hit->part = HIT_CY_SIDE;
-		// if (dot(hit->norm, cy->ray.dir) > 0)
-		// 	hit->norm = vec_scale(hit->norm, -1.0);
-		return (true);
-	}
-	return (false);
 }

--- a/src/raytracing/render.c
+++ b/src/raytracing/render.c
@@ -5,18 +5,6 @@
 #include <mlx.h>
 #include <math.h>
 
-static void	reset_light_flags(t_env *env)
-{
-	t_lit	*l;
-
-	l = env->lit;
-	while (l)
-	{
-		l->valid_flag = true;
-		l = l->next;
-	}
-}
-
 static t_obj	get_indexed_obj(int index, t_obj *obj)
 {
 	t_obj	*ret;
@@ -38,16 +26,36 @@ static t_obj	get_indexed_obj(int index, t_obj *obj)
 	return (*ret);
 }
 
-static void	init_offset(double sx[4], double sy[4])
+static t_xyz	render_sample(t_obj *obj, t_env *env, double x, double y)
 {
-	sx[0] = 0.25;
-	sx[1] = 0.75;
-	sx[2] = 0.25;
-	sx[3] = 0.75;
-	sy[0] = 0.25;
-	sy[1] = 0.25;
-	sy[2] = 0.75;
-	sy[3] = 0.75;
+	t_xyz	screen_vec;
+	t_xyz	color;
+	t_ray	cam_ray;
+
+	set_screen_vector(&screen_vec, x, y, env->cam_degree);
+	cam_ray.pos = env->cam_xyz;
+	cam_ray.dir = calc_cam_dir(screen_vec, env->cam_vector);
+	reset_light_flags(env);
+	ray_tracing(obj, env, cam_ray, &color);
+	return (color);
+}
+
+static t_xyz	render_pixel(t_obj *obj, t_env *env, int x, int y)
+{
+	double	sx[4];
+	double	sy[4];
+	t_xyz	color;
+	int		i;
+
+	init_offset(sx, sy);
+	init_xyz(&color);
+	i = 0;
+	while (i < 4)
+	{
+		color = vec_add(color, render_sample(obj, env, x + sx[i], y + sy[i]));
+		i++;
+	}
+	return (vec_div(color, 4.0));
 }
 
 int	render_scene(t_mlx_env *mlx, t_obj *obj, t_env *env)
@@ -55,31 +63,14 @@ int	render_scene(t_mlx_env *mlx, t_obj *obj, t_env *env)
 	double	x;
 	double	y;
 	t_xyz	color;
-	t_xyz	sample_color;
-	t_xyz	screen_vec;
-	t_ray	cam_ray;
-	double	sx[4];
-	double	sy[4];
-	int		i;
 
-	init_offset(sx, sy);
 	y = -1;
 	while (++y < W_HEIGHT)
 	{
 		x = -1;
 		while (++x < W_WIDTH)
 		{
-			init_xyz(&color);
-			i = -1;
-			while (++i < 4) {
-				set_screen_vector(&screen_vec, x + sx[i], y + sy[i], env->cam_degree);
-				cam_ray.pos = env->cam_xyz;
-				cam_ray.dir = calc_cam_dir(screen_vec, env->cam_vector);
-				reset_light_flags(env);
-				ray_tracing(obj, env, cam_ray, &sample_color);
-				color = vec_add(color, sample_color);
-			}
-			color = vec_div(color, 4.0);
+			color = render_pixel(obj, env, x, y);
 			color_set_to_pixel
 				(mlx->img, x, y, make_trgb(0, color.x, color.y, color.z));
 		}

--- a/src/raytracing/render_utils.c
+++ b/src/raytracing/render_utils.c
@@ -1,0 +1,30 @@
+#include "parser.h"
+#include "raytracing.h"
+#include "ui.h"
+#include "calc.h"
+#include <mlx.h>
+#include <math.h>
+
+void	reset_light_flags(t_env *env)
+{
+	t_lit	*l;
+
+	l = env->lit;
+	while (l)
+	{
+		l->valid_flag = true;
+		l = l->next;
+	}
+}
+
+void	init_offset(double sx[4], double sy[4])
+{
+	sx[0] = 0.25;
+	sx[1] = 0.75;
+	sx[2] = 0.25;
+	sx[3] = 0.75;
+	sy[0] = 0.25;
+	sy[1] = 0.25;
+	sy[2] = 0.75;
+	sy[3] = 0.75;
+}

--- a/src/raytracing/shade.c
+++ b/src/raytracing/shade.c
@@ -6,7 +6,7 @@
 /*   By: yosshii <yosshii@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/23 19:09:51 by tamatsuu          #+#    #+#             */
-/*   Updated: 2026/04/17 21:32:24 by yosshii          ###   ########.fr       */
+/*   Updated: 2026/04/18 13:47:51 by yosshii          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,16 @@
 #include "raytracing.h"
 #include "calc.h"
 #include <math.h>
+
+static inline t_data_set	set_data(t_obj *obj, t_lit *lit, t_hit_point hit)
+{
+	t_data_set	data;
+
+	data.obj = obj;
+	data.lit = lit;
+	data.hit_p = hit;
+	return (data);
+}
 
 // this function calculate shade.
 // shade including diffuse reflection and specular reflection
@@ -38,25 +48,24 @@ t_xyz	calc_shade(t_obj *obj, t_lit *lit, t_hit_point hit_obj, t_ray cam_ray)
 		specular_ref = dot(reverse_vec, view_dir);
 		specular_ref = pow(clamp_double(specular_ref, 0.0, 1.0), SHINENESS);
 	}
-	return (pls_shade(obj, hit_obj, lit, dot_res, specular_ref));
+	return (pls_shade(set_data(obj, lit, hit_obj), dot_res, specular_ref));
 }
 
-t_xyz	pls_shade(t_obj *obj, t_hit_point hit, t_lit *lit, double diff_ref,
-	double spec_ref)
+t_xyz	pls_shade(t_data_set data, double diff_ref, double spec_ref)
 {
 	t_xyz	dif_col;
 	t_xyz	spec_col;
-	t_xyz	ret_col;
 	t_xyz	lit_rgb;
 	t_xyz	base_color;
+	t_xyz	ret_col;
 
-	base_color = get_optional_color(obj, hit);
-	lit_rgb = lit->rgb;
+	base_color = get_optional_color(data.obj, data.hit_p);
+	lit_rgb = data.lit->rgb;
 	lit_rgb = vec_div(lit_rgb, 255.0);
 	dif_col = vec_scale(vec_mul(base_color, lit_rgb), diff_ref);
-	dif_col = vec_scale(dif_col, lit->t);
+	dif_col = vec_scale(dif_col, data.lit->t);
 	spec_col = vec_scale(vec_scale(lit_rgb, 255.0), spec_ref);
-	spec_col = vec_scale(spec_col, lit->t);
+	spec_col = vec_scale(spec_col, data.lit->t);
 	ret_col = vec_add(dif_col, spec_col);
 	return (ret_col);
 }

--- a/src/raytracing/shade.c
+++ b/src/raytracing/shade.c
@@ -6,7 +6,7 @@
 /*   By: yosshii <yosshii@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/23 19:09:51 by tamatsuu          #+#    #+#             */
-/*   Updated: 2026/04/16 23:40:28 by yosshii          ###   ########.fr       */
+/*   Updated: 2026/04/17 21:32:24 by yosshii          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,8 @@ t_xyz	calc_shade(t_obj *obj, t_lit *lit, t_hit_point hit_obj, t_ray cam_ray)
 	return (pls_shade(obj, hit_obj, lit, dot_res, specular_ref));
 }
 
-t_xyz	pls_shade(t_obj *obj, t_hit_point hit, t_lit *lit, double diff_ref, double spec_ref)
+t_xyz	pls_shade(t_obj *obj, t_hit_point hit, t_lit *lit, double diff_ref,
+	double spec_ref)
 {
 	t_xyz	dif_col;
 	t_xyz	spec_col;

--- a/src/raytracing/texture.c
+++ b/src/raytracing/texture.c
@@ -5,11 +5,11 @@
 
 t_xyz	get_optional_color(t_obj *obj, t_hit_point hit)
 {
-	if (obj->id == PL && obj->texture == IM &&
-		(obj->vector.y == 1 || obj->vector.y == -1))
+	if (obj->id == PL && obj->texture == IM
+		&& (obj->vector.y == 1 || obj->vector.y == -1))
 		return (get_pl_texture_color(obj, hit, &(obj->tex)));
-	if (obj->id == PL && obj->texture == CH &&
-		(obj->vector.y == 1 || obj->vector.y == -1))
+	if (obj->id == PL && obj->texture == CH
+		&& (obj->vector.y == 1 || obj->vector.y == -1))
 		return (get_pl_checker_color(obj, hit));
 	if (obj->id == SP && obj->texture == IM)
 		return (get_sp_texture_color(obj, hit, &(obj->tex)));
@@ -30,4 +30,3 @@ t_xyz	color_from_int(unsigned int c)
 {
 	return (make_xyz((c >> 16) & 0xFF, (c >> 8) & 0xFF, c & 0xFF));
 }
-

--- a/src/ui/init_window.c
+++ b/src/ui/init_window.c
@@ -6,7 +6,7 @@
 /*   By: yosshii <yosshii@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/20 18:54:11 by tamatsuu          #+#    #+#             */
-/*   Updated: 2026/04/16 22:50:46 by yosshii          ###   ########.fr       */
+/*   Updated: 2026/04/17 21:35:13 by yosshii          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,14 +24,14 @@ static void	load_textures(t_mlx_env *mlx, t_obj *obj)
 		if (obj->texture == IM && obj->filename)
 		{
 			obj->tex.img = mlx_xpm_file_to_image(
-				mlx->mlx, obj->filename, &obj->tex.width, &obj->tex.height
-			);
+					mlx->mlx, obj->filename, &obj->tex.width, &obj->tex.height
+					);
 			if (!obj->tex.img)
 				print_error_and_exit("image load error", obj->filename);
 			obj->tex.addr = mlx_get_data_addr(
-				obj->tex.img, &obj->tex.bits_per_pixel,
-				&obj->tex.line_length, &obj->tex.endian
-			);
+					obj->tex.img, &obj->tex.bits_per_pixel,
+					&obj->tex.line_length, &obj->tex.endian
+					);
 			if (!obj->tex.addr)
 				print_error_and_exit("mlx_get_data_addr", "failed");
 		}
@@ -46,10 +46,10 @@ int	init_window(t_obj *obj, t_env *env)
 	mlx.mlx = mlx_init();
 	if (!mlx.mlx)
 		print_error_and_exit("mlx_init", "failed");
+	load_textures(&mlx, obj);
 	mlx.window = mlx_new_window(mlx.mlx, W_WIDTH, W_HEIGHT, WIN_TITLE);
 	if (!mlx.window)
 		print_error_and_exit("mlx_new_window", "failed");
-	load_textures(&mlx, obj);
 	mlx_key_hook(mlx.window, key_handler, &mlx);
 	render_window(&mlx, obj, env);
 	mlx_hook(mlx.window, DESTROY_NOTIFY, 0, close_btn_click, &mlx);
@@ -68,7 +68,8 @@ int	render_window(t_mlx_env *mlx, t_obj *obj, t_env *env)
 	if (!mlx->img->img)
 		print_error_and_exit("mlx_new_image failed", NULL);
 	mlx->img->addr = mlx_get_data_addr(mlx->img->img,
-			&mlx->img->bits_per_pixel, &mlx->img->line_length, &mlx->img->endian);
+			&mlx->img->bits_per_pixel, &mlx->img->line_length,
+			&mlx->img->endian);
 	if (!mlx->img->addr)
 		print_error_and_exit("mlx_get_data_addr failed", NULL);
 	render_scene(mlx, obj, env);


### PR DESCRIPTION
Norm対応を行った
引数、行数オーバーのところは、補助関数、構造体を使って解決した
ft_memcmpが危険との指摘だったので、ft_strncmpに差し替えた
終了時ESCでセグフォが起こったので、freeやdestroy関連を見直した